### PR TITLE
Correct import errors and update CLI help

### DIFF
--- a/eda/cli.py
+++ b/eda/cli.py
@@ -4,19 +4,19 @@ import sys
 
 from argparse import ArgumentParser
 
-from photochemistry import kinetics
-from photochemistry import spectrum
+from eda import kinetics
+from eda import spectrum
 
 
 class CliParser:
     def __init__(self):
         parser = ArgumentParser(
-            description="Photochemistry data analysis tools",
+            description="Tools for easy scientific data analysis",
             usage="pchem <command> <subcommand> [parameters]",
         )
         parser.add_argument(
             "command",
-            help="Command to run. Valid commands are {plot}",
+            help="Valid commands are {plot}",
         )
         args = parser.parse_args(sys.argv[1:2])
         if not hasattr(self, args.command):
@@ -34,7 +34,7 @@ class CliParser:
         parser.add_argument(
             "subcommand",
             help=(
-                "Subcommand to run. Valid subcommands are {spectrum,kinetics}"
+                "Valid subcommands are {spectrum,kinetics}"
             ),
         )
         args = parser.parse_args(sys.argv[2:3])

--- a/eda/kinetics.py
+++ b/eda/kinetics.py
@@ -11,7 +11,7 @@ import pandas as pd
 
 from scipy.optimize import curve_fit
 
-from photochemistry.utils import linuxize_newlines
+from eda.utils import linuxize_newlines
 
 # curve fitting initial parameters
 INIT_PARAMS = [-1, -1, 1]

--- a/eda/spectrum.py
+++ b/eda/spectrum.py
@@ -8,7 +8,7 @@ from tempfile import TemporaryDirectory
 import matplotlib.pyplot as plt
 import pandas as pd
 
-from photochemistry.utils import linuxize_newlines
+from eda.utils import linuxize_newlines
 
 # CSV file parameters
 WAVELENGTH_COL = "Wavelength (nm)"


### PR DESCRIPTION
Python modules were still imported from the older namespace. The CLI
help was still describing the package as photochemistry-oriented only.